### PR TITLE
add option to report sigma from get_buffer()

### DIFF
--- a/R/buffer_fxn.R
+++ b/R/buffer_fxn.R
@@ -85,7 +85,7 @@ get_buffer <- function(years, sigma, pstar, m = NULL, verbose = TRUE) {
     sigma_calc[category_3] <- 2.0 # cap sigma to match the capped buffer for those years
   }
 
-  # combine resulting into a table for output
+  # combine results into a table for output
   out <- data.frame(
     year = years,
     # buffer is typically rounded to 3 digits

--- a/R/buffer_fxn.R
+++ b/R/buffer_fxn.R
@@ -18,6 +18,8 @@
 #' @param m A vector of natural mortality value(s) by sex. If added the function will
 #'   calculate the geometric mean to determine if m > 0.15 which requires a higher
 #'   rate of change in sigma. Default is NULL.
+#' @param report_sigma A logical that specifies if you want to include a column
+#'   of the sigma values used in the buffer calculation. The default is `FALSE`.
 #' @param verbose A logical that specifies if you want to print messages and
 #'   warnings to the console. The default is `TRUE`.
 #'
@@ -27,7 +29,7 @@
 #' @author written by Chantel Wetzel
 #' @export
 #'
-get_buffer <- function(years, sigma, pstar, m = NULL, verbose = TRUE) {
+get_buffer <- function(years, sigma, pstar, m = NULL, report_sigma = FALSE, verbose = TRUE) {
   r <- dplyr::case_when(
     sigma == 2.0 ~ 0,
     sigma < 2.0 ~ 0.075
@@ -80,7 +82,16 @@ get_buffer <- function(years, sigma, pstar, m = NULL, verbose = TRUE) {
   out <- data.frame(
     year = years,
     buffer = round(buffer, 3)
+
   )
+
+  # optionally report sigma
+  # rounding to 4 digits because the for many stocks, the combination of the 
+  # 0.075 adjustment and the default sigma = 0.5 is exact to 4 digits. 
+  if (report_sigma) {
+    out$hash <- "#"
+    out$sigma <- round(sigma_calc, 4) 
+  }
 
   return(out)
 }

--- a/R/buffer_fxn.R
+++ b/R/buffer_fxn.R
@@ -93,7 +93,7 @@ get_buffer <- function(years, sigma, pstar, m = NULL, verbose = TRUE) {
     # adding a column of "#" so the sigma column will be ignored
     # by SS3 when reading the forecast file
     hash = "#",
-    # rounding sigma to 4 digits because the for many stocks the
+    # rounding sigma to 4 digits because for many stocks the
     # 0.075 adjustment and the default sigma = 0.5 result in values
     # that are exact to 4 digits.
     sigma = round(sigma_calc, 4)

--- a/R/buffer_fxn.R
+++ b/R/buffer_fxn.R
@@ -18,18 +18,23 @@
 #' @param m A vector of natural mortality value(s) by sex. If added the function will
 #'   calculate the geometric mean to determine if m > 0.15 which requires a higher
 #'   rate of change in sigma. Default is NULL.
-#' @param report_sigma A logical that specifies if you want to include a column
-#'   of the sigma values used in the buffer calculation. The default is `FALSE`.
 #' @param verbose A logical that specifies if you want to print messages and
 #'   warnings to the console. The default is `TRUE`.
 #'
 #' @examples
 #' get_buffer(years = 2025:2036, sigma = 1.0, pstar = 0.4)
 #' get_buffer(years = 2025:2036, sigma = 0.5, pstar = 0.45, m = c(0.16, 0.18))
+#' \dontrun{
+#'   # add buffer to forecast file of SS3 model
+#'   inputs <- r4ss::SS_read(mydir)
+#'   inputs$fore$Flimitfraction <- -1 # set to -1 to use matrix of time-varying buffers
+#'   inputs$fore$Flimitfraction_m <- get_buffer(years = 2025:2036, sigma = 1.0, pstar = 0.4)
+#'   r4ss::SS_write(inputs, dir = mydir, overwrite = TRUE)
+#' }
 #' @author written by Chantel Wetzel
 #' @export
 #'
-get_buffer <- function(years, sigma, pstar, m = NULL, report_sigma = FALSE, verbose = TRUE) {
+get_buffer <- function(years, sigma, pstar, m = NULL, verbose = TRUE) {
   r <- dplyr::case_when(
     sigma == 2.0 ~ 0,
     sigma < 2.0 ~ 0.075
@@ -77,21 +82,22 @@ get_buffer <- function(years, sigma, pstar, m = NULL, report_sigma = FALSE, verb
       }
     }
     buffer[category_3] <- max_buffer
+    sigma_calc[category_3] <- 2.0 # cap sigma to match the capped buffer for those years
   }
 
+  # combine resulting into a table for output
   out <- data.frame(
     year = years,
-    buffer = round(buffer, 3)
-
+    # buffer is typically rounded to 3 digits
+    buffer = round(buffer, 3),
+    # adding a column of "#" so the sigma column will be ignored
+    # by SS3 when reading the forecast file
+    hash = "#",
+    # rounding sigma to 4 digits because the for many stocks the
+    # 0.075 adjustment and the default sigma = 0.5 result in values
+    # that are exact to 4 digits.
+    sigma = round(sigma_calc, 4)
   )
-
-  # optionally report sigma
-  # rounding to 4 digits because the for many stocks, the combination of the 
-  # 0.075 adjustment and the default sigma = 0.5 is exact to 4 digits. 
-  if (report_sigma) {
-    out$hash <- "#"
-    out$sigma <- round(sigma_calc, 4) 
-  }
 
   return(out)
 }

--- a/man/get_buffer.Rd
+++ b/man/get_buffer.Rd
@@ -4,7 +4,7 @@
 \alias{get_buffer}
 \title{Buffer calculation for West Coast groundish assessments}
 \usage{
-get_buffer(years, sigma, pstar, m = NULL, verbose = TRUE)
+get_buffer(years, sigma, pstar, m = NULL, report_sigma = FALSE, verbose = TRUE)
 }
 \arguments{
 \item{years}{Years to generate buffer values. The first year should align with
@@ -20,6 +20,9 @@ assessment categories (cat 1 = 0.50, cat 2 = 1.0, cat 3 = 2.0). For categories
 \item{m}{A vector of natural mortality value(s) by sex. If added the function will
 calculate the geometric mean to determine if m > 0.15 which requires a higher
 rate of change in sigma. Default is NULL.}
+
+\item{report_sigma}{A logical that specifies if you want to include a column
+of the sigma values used in the buffer calculation. The default is \code{FALSE}.}
 
 \item{verbose}{A logical that specifies if you want to print messages and
 warnings to the console. The default is \code{TRUE}.}

--- a/man/get_buffer.Rd
+++ b/man/get_buffer.Rd
@@ -4,7 +4,7 @@
 \alias{get_buffer}
 \title{Buffer calculation for West Coast groundish assessments}
 \usage{
-get_buffer(years, sigma, pstar, m = NULL, report_sigma = FALSE, verbose = TRUE)
+get_buffer(years, sigma, pstar, m = NULL, verbose = TRUE)
 }
 \arguments{
 \item{years}{Years to generate buffer values. The first year should align with
@@ -20,9 +20,6 @@ assessment categories (cat 1 = 0.50, cat 2 = 1.0, cat 3 = 2.0). For categories
 \item{m}{A vector of natural mortality value(s) by sex. If added the function will
 calculate the geometric mean to determine if m > 0.15 which requires a higher
 rate of change in sigma. Default is NULL.}
-
-\item{report_sigma}{A logical that specifies if you want to include a column
-of the sigma values used in the buffer calculation. The default is \code{FALSE}.}
 
 \item{verbose}{A logical that specifies if you want to print messages and
 warnings to the console. The default is \code{TRUE}.}
@@ -41,6 +38,13 @@ from past stock assessments. Fisheries Research 262: 106659.
 \examples{
 get_buffer(years = 2025:2036, sigma = 1.0, pstar = 0.4)
 get_buffer(years = 2025:2036, sigma = 0.5, pstar = 0.45, m = c(0.16, 0.18))
+\dontrun{
+  # add buffer to forecast file of SS3 model
+  inputs <- r4ss::SS_read(mydir)
+  inputs$fore$Flimitfraction <- -1 # set to -1 to use matrix of time-varying buffers
+  inputs$fore$Flimitfraction_m <- get_buffer(years = 2025:2036, sigma = 1.0, pstar = 0.4)
+  r4ss::SS_write(inputs, dir = mydir, overwrite = TRUE)
+}
 }
 \author{
 written by Chantel Wetzel


### PR DESCRIPTION
An in-prep SSC request for widow rockfish projections includes the use of the time-varying sigma for calculating probabilities.
It occurred to me that the most accurate way to get the annual sigma values would be directly from `get_buffer()` since they are used in the internal calculations.

Example output of the revised function is pasted below.

The `hash` column is included so that the expanded table could still be pasted into a forecast file without messing up the SS3 read of the two input columns, but we could also leave it to the users to deal with this. I also kept the default of NOT including the sigma column in case including it messes up any existing code.

@chantelwetzel-noaa, if you think this is a bad idea, or don't agree with the choices I made in implementing it, I'm happy to change.

```
> get_buffer(years = 2025:2036, sigma = 0.5, pstar = 0.45, report_sigma = TRUE)
No natural mortality values provided and is assumed to be =< 0.15.
The sigma value of 0.5 adjusts yearly by the rate of 0.075.
   year buffer hash  sigma
1  2025  1.000    # 0.5000
2  2026  1.000    # 0.5000
3  2027  0.935    # 0.5375
4  2028  0.930    # 0.5750
5  2029  0.926    # 0.6125
6  2030  0.922    # 0.6500
7  2031  0.917    # 0.6875
8  2032  0.913    # 0.7250
9  2033  0.909    # 0.7625
10 2034  0.904    # 0.8000
11 2035  0.900    # 0.8375
12 2036  0.896    # 0.8750
```
